### PR TITLE
Print node version

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,4 +1,12 @@
 steps:
+  - name: ":node: Version"
+    plugins:
+      - docker-compose#v3.9.0:
+          run: app
+          command:
+            - node
+            - --version
+
   - name: ":node:"
     command: npm test
     plugins:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:latest
+FROM node:18
 
 RUN mkdir /app
 WORKDIR /app


### PR DESCRIPTION
Some customers are asking how to run node 18 on the Elastic CI Stack for AWS. The answer is to do it in docker, and I want to send them to this repo as an example. It would be good to print the node version in a job in the pipeline so that they can verify this more easily when they run this themselves.