### PR TITLE
Link to public pipeline, add screenshot

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,8 +1,11 @@
 # Buildkite Node.js Docker Example
 
+[![Build status](https://badge.buildkite.com/a9d2e75d3a3a450b44b12f0e592899b98375217e54a346cde8.svg?branch=main)](https://buildkite.com/buildkite/nodejs-docker-example/builds/latest?branch=main)
 [![Add to Buildkite](https://buildkite.com/button.svg)](https://buildkite.com/new)
 
 This repository is an example on how to test a [Node.js](https://nodejs.org/) project using [Buildkite](https://buildkite.com/) and [Docker](https://docker.com/). It uses the standard [Node.js Docker image](https://hub.docker.com/_/node/) and [Buildkite’s Docker-based Builds](https://buildkite.com/docs/guides/docker-containerized-builds).
+
+<img width="1502" alt="Sreenshot of Buildkite Node.js Docker example pipeline" src="https://github.com/user-attachments/assets/5b5adab3-b3a2-44c5-926d-72e8abe2904b" />
 
 ## Running locally
 


### PR DESCRIPTION
Same as https://github.com/buildkite/nodejs-example/pull/31 - make sure folks can see what [this pipeline](https://buildkite.com/buildkite/nodejs-docker-example/builds/1#0196fbfe-bf54-48aa-8ed2-fa921626c555) looks like for real, as well as adding it to play themselves.

<img width="1053" alt="image" src="https://github.com/user-attachments/assets/bfeee096-30a1-4941-8157-9d3640275132" />
